### PR TITLE
Fix ignored author and missing subtitle data

### DIFF
--- a/archetypes/audio.md
+++ b/archetypes/audio.md
@@ -1,7 +1,10 @@
+{{ $author := slice "" -}}
+{{ with .Site.Author }}{{ $author = . }}{{ end -}}
 ---
 title: "{{ replace .Name "-" " " | title }}"
 type: audio
-author: Sebastian
+author: {{ range $author }}
+    - {{ . }}{{ end }} 
 date: {{ .Date }}
 publishdate: {{ now.Format "2006-01-02" }}
 lastmod: {{ now.Format "2006-01-02" }}

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,7 +1,10 @@
+{{ $author := slice "" -}}
+{{ with .Site.Author }}{{ $author = . }}{{ end -}}
 ---
 title: "{{ replace .Name "-" " " | title }}"
 type: page
-author: Sebastian
+author: {{ range $author }}
+    - {{ . }}{{ end }} 
 date: {{ .Date }}
 publishdate: {{ now.Format "2006-01-02" }}
 lastmod: {{ now.Format "2006-01-02" }}

--- a/archetypes/link.md
+++ b/archetypes/link.md
@@ -1,7 +1,10 @@
+{{ $author := slice "" -}}
+{{ with .Site.Author }}{{ $author = . }}{{ end -}}
 ---
 title: "{{ replace .Name "-" " " | title }}"
 type: link
-author: Sebastian
+author: {{ range $author }}
+    - {{ . }}{{ end }} 
 date: {{ .Date }}
 publishdate: {{ now.Format "2006-01-02" }}
 lastmod: {{ now.Format "2006-01-02" }}

--- a/archetypes/post.md
+++ b/archetypes/post.md
@@ -1,7 +1,10 @@
+{{ $author := slice "" -}}
+{{ with .Site.Author }}{{ $author = . }}{{ end -}}
 ---
 title: "{{ replace .Name "-" " " | title }}"
 type: post
-author: Sebastian
+author: {{ range $author }}
+    - {{ . }}{{ end }} 
 date: {{ .Date }}
 publishdate: {{ now.Format "2006-01-02" }}
 lastmod: {{ now.Format "2006-01-02" }}

--- a/archetypes/quote.md
+++ b/archetypes/quote.md
@@ -1,7 +1,10 @@
+{{ $author := slice "" -}}
+{{ with .Site.Author }}{{ $author = . }}{{ end -}}
 ---
 title: "{{ replace .Name "-" " " | title }}"
 type: link
-author: Sebastian
+author: {{ range $author }}
+    - {{ . }}{{ end }} 
 date: {{ .Date }}
 publishdate: {{ now.Format "2006-01-02" }}
 lastmod: {{ now.Format "2006-01-02" }}

--- a/archetypes/video.md
+++ b/archetypes/video.md
@@ -1,7 +1,10 @@
+{{ $author := slice "" -}}
+{{ with .Site.Author }}{{ $author = . }}{{ end -}}
 ---
 title: "{{ replace .Name "-" " " | title }}"
 type: video
-author: Sebastian
+author: {{ range $author }}
+    - {{ . }}{{ end }} 
 date: {{ .Date }}
 publishdate: {{ now.Format "2006-01-02" }}
 lastmod: {{ now.Format "2006-01-02" }}

--- a/layouts/partials/content_card_body.html
+++ b/layouts/partials/content_card_body.html
@@ -5,7 +5,7 @@
     <h1 class="card-title"><a href="{{ .RelPermalink }}">{{ .Title | markdownify }}</a></h1>
     <h6 class="card-subtitle mb-2 text-muted">
         <i class="fas fa-calendar-day"></i>&nbsp;{{ .PublishDate.Format $customDateFormat }}{{ if gt .Lastmod .PublishDate }}, {{ i18n "lastupdated" }} {{ .Lastmod.Format $customDateFormat }}{{ end }} -
-        <i class="fas fa-user"></i>&nbsp;{{ range .Site.Author }}{{ . }}{{ end }}
+        <i class="fas fa-user"></i>&nbsp;{{ if reflect.IsSlice ($.Param "author") }}{{ range $.Param "author" }}{{ . }}{{ end }}{{ else }}{{ $.Param "author" }}{{ end }}
         {{ if ne .Site.Params.hideReadingTime true }}
             {{ if and (not (.Scratch.Get "showPostSummary")) (.Scratch.Get "fullsize") }}
                 - <i class="fas fa-clock"></i>&nbsp;~{{ i18n "readingTime" .ReadingTime }}

--- a/layouts/partials/content_card_body.html
+++ b/layouts/partials/content_card_body.html
@@ -1,18 +1,48 @@
 {{ $customDateFormat := "02.01.2006" }}
 {{ with .Site.Params.customDateFormat }}{{ $customDateFormat = . }}{{ end }}
 
+{{ $card_subtitle_data := slice }}
+{{ if isset .Params "publishdate" }}
+    {{ $pub_string := "<i class=\"fas fa-calendar-day\"></i>&nbsp;" }} 
+    {{ $update_string := "" }}
+    {{ if gt .Lastmod .PublishDate }}
+        {{ $update_label := i18n "lastupdated" }}
+        {{ $update_date := .Lastmod.Format $customDateFormat }}
+        {{ $update_string = printf "%s%s %s" ", " $update_label $update_date | htmlEscape}}
+    {{ end }}
+    {{ $pub_date := .PublishDate.Format $customDateFormat | htmlEscape }}
+    {{ $pub_string := printf "%s%s%s" $pub_string $pub_date $update_string }}
+    {{ $card_subtitle_data = $card_subtitle_data | append $pub_string }}
+{{ end }}
+{{ if isset .Params "author" }}
+    {{ $author := $.Param "author" }}
+    {{ $author_string := "<i class=\"fas fa-user\"></i>&nbsp;" }}
+    {{ $author_data := "" }}
+    {{ if reflect.IsSlice ($author) }}
+        {{ $author_data = delimit $author ", " | htmlEscape }}
+    {{ else }}
+        {{ $author_data = $author | htmlEscape }}
+    {{ end }}
+    {{ $author_string := printf "%s%s" $author_string $author_data }}
+    {{ $card_subtitle_data = $card_subtitle_data | append $author_string }}
+{{ end }}
+{{ if ne .Site.Params.hideReadingTime true }}
+    {{ $read_time_string := "<i class=\"fas fa-clock\"></i>&nbsp;~" }}
+    {{ if and (not (.Scratch.Get "showPostSummary")) (.Scratch.Get "fullsize") }}
+        {{ $read_time_data := i18n "readingTime" .ReadingTime | htmlEscape }}
+        {{ $read_time_string := printf "%s%s" $read_time_string $read_time_data }}
+        {{ $card_subtitle_data = $card_subtitle_data | append $read_time_string }}
+    {{ end }}
+{{ end }}
+
 <div class="card-body">
     <h1 class="card-title"><a href="{{ .RelPermalink }}">{{ .Title | markdownify }}</a></h1>
+    {{ $card_subtitle_length := len $card_subtitle_data }}
+    {{ if gt $card_subtitle_length 0 }}
     <h6 class="card-subtitle mb-2 text-muted">
-        <i class="fas fa-calendar-day"></i>&nbsp;{{ .PublishDate.Format $customDateFormat }}{{ if gt .Lastmod .PublishDate }}, {{ i18n "lastupdated" }} {{ .Lastmod.Format $customDateFormat }}{{ end }} -
-        <i class="fas fa-user"></i>&nbsp;{{ if reflect.IsSlice ($.Param "author") }}{{ range $.Param "author" }}{{ . }}{{ end }}{{ else }}{{ $.Param "author" }}{{ end }}
-        {{ if ne .Site.Params.hideReadingTime true }}
-            {{ if and (not (.Scratch.Get "showPostSummary")) (.Scratch.Get "fullsize") }}
-                - <i class="fas fa-clock"></i>&nbsp;~{{ i18n "readingTime" .ReadingTime }}
-            {{ end }}
-        {{ end }}
+        {{ delimit $card_subtitle_data " - " | safeHTML }}
     </h6>
-
+    {{ end }}
     {{ if eq .Type "video" }}
     {{ else if eq .Type "audio" }}
     {{ else if eq .Type "link" }}

--- a/layouts/partials/content_card_body.html
+++ b/layouts/partials/content_card_body.html
@@ -1,48 +1,6 @@
-{{ $customDateFormat := "02.01.2006" }}
-{{ with .Site.Params.customDateFormat }}{{ $customDateFormat = . }}{{ end }}
-
-{{ $card_subtitle_data := slice }}
-{{ if isset .Params "publishdate" }}
-    {{ $pub_string := "<i class=\"fas fa-calendar-day\"></i>&nbsp;" }} 
-    {{ $update_string := "" }}
-    {{ if gt .Lastmod .PublishDate }}
-        {{ $update_label := i18n "lastupdated" }}
-        {{ $update_date := .Lastmod.Format $customDateFormat }}
-        {{ $update_string = printf "%s%s %s" ", " $update_label $update_date | htmlEscape}}
-    {{ end }}
-    {{ $pub_date := .PublishDate.Format $customDateFormat | htmlEscape }}
-    {{ $pub_string := printf "%s%s%s" $pub_string $pub_date $update_string }}
-    {{ $card_subtitle_data = $card_subtitle_data | append $pub_string }}
-{{ end }}
-{{ if isset .Params "author" }}
-    {{ $author := $.Param "author" }}
-    {{ $author_string := "<i class=\"fas fa-user\"></i>&nbsp;" }}
-    {{ $author_data := "" }}
-    {{ if reflect.IsSlice ($author) }}
-        {{ $author_data = delimit $author ", " | htmlEscape }}
-    {{ else }}
-        {{ $author_data = $author | htmlEscape }}
-    {{ end }}
-    {{ $author_string := printf "%s%s" $author_string $author_data }}
-    {{ $card_subtitle_data = $card_subtitle_data | append $author_string }}
-{{ end }}
-{{ if ne .Site.Params.hideReadingTime true }}
-    {{ $read_time_string := "<i class=\"fas fa-clock\"></i>&nbsp;~" }}
-    {{ if and (not (.Scratch.Get "showPostSummary")) (.Scratch.Get "fullsize") }}
-        {{ $read_time_data := i18n "readingTime" .ReadingTime | htmlEscape }}
-        {{ $read_time_string := printf "%s%s" $read_time_string $read_time_data }}
-        {{ $card_subtitle_data = $card_subtitle_data | append $read_time_string }}
-    {{ end }}
-{{ end }}
-
 <div class="card-body">
     <h1 class="card-title"><a href="{{ .RelPermalink }}">{{ .Title | markdownify }}</a></h1>
-    {{ $card_subtitle_length := len $card_subtitle_data }}
-    {{ if gt $card_subtitle_length 0 }}
-    <h6 class="card-subtitle mb-2 text-muted">
-        {{ delimit $card_subtitle_data " - " | safeHTML }}
-    </h6>
-    {{ end }}
+    {{ partial "content_card_body_subtitle.html" . }}
     {{ if eq .Type "video" }}
     {{ else if eq .Type "audio" }}
     {{ else if eq .Type "link" }}

--- a/layouts/partials/content_card_body_subtitle.html
+++ b/layouts/partials/content_card_body_subtitle.html
@@ -1,0 +1,40 @@
+{{- $customDateFormat := "02.01.2006" -}}
+{{- with .Site.Params.customDateFormat -}}{{- $customDateFormat = . -}}{{- end -}}
+
+{{- $card_subtitle_data := slice -}}
+{{- if isset .Params "publishdate" -}}
+    {{- $pub_string := "<i class=\"fas fa-calendar-day\"></i>&nbsp;" -}} 
+    {{- $update_string := "" -}}
+    {{- if gt .Lastmod .PublishDate -}}
+        {{- $update_label := i18n "lastupdated" -}}
+        {{- $update_date := .Lastmod.Format $customDateFormat -}}
+        {{- $update_string = printf "%s%s %s" ", " $update_label $update_date | htmlEscape}}
+    {{- end -}}
+    {{- $pub_date := .PublishDate.Format $customDateFormat | htmlEscape -}}
+    {{- $pub_string := printf "%s%s%s" $pub_string $pub_date $update_string -}}
+    {{- $card_subtitle_data = $card_subtitle_data | append $pub_string -}}
+{{- end -}}
+{{- if isset .Params "author" -}}
+    {{- $author := $.Param "author" -}}
+    {{- $author_string := "<i class=\"fas fa-user\"></i>&nbsp;" -}}
+    {{- $author_data := "" -}}
+    {{- if reflect.IsSlice ($author) -}}
+        {{- $author_data = delimit $author ", " | htmlEscape -}}
+    {{- else -}}
+        {{- $author_data = $author | htmlEscape -}}
+    {{- end -}}
+    {{- $author_string := printf "%s%s" $author_string $author_data -}}
+    {{- $card_subtitle_data = $card_subtitle_data | append $author_string -}}
+{{- end -}}
+{{- if ne .Site.Params.hideReadingTime true -}}
+    {{- $read_time_string := "<i class=\"fas fa-clock\"></i>&nbsp;~" -}}
+    {{- if and (not (.Scratch.Get "showPostSummary")) (.Scratch.Get "fullsize") -}}
+        {{- $read_time_data := i18n "readingTime" .ReadingTime | htmlEscape -}}
+        {{- $read_time_string := printf "%s%s" $read_time_string $read_time_data -}}
+        {{- $card_subtitle_data = $card_subtitle_data | append $read_time_string -}}
+    {{- end -}}
+{{- end -}}
+{{- $card_subtitle_length := len $card_subtitle_data -}}
+{{- if gt $card_subtitle_length 0 -}}
+<h6 class="card-subtitle mb-2 text-muted">{{ delimit $card_subtitle_data " - " | safeHTML }}</h6>
+{{- end -}}


### PR DESCRIPTION
The first commit in this PR sets the default author in archetypes' front matter to the site's defined Author, or leave it empty if not set, then use the page's defined Author(s) when outputting content.

The second commit removes any data (date, author, reading time) that wasn't set from the cards subtitles. The subtitle is removed entirely if no data was set at all.

Fix #15 