### PR TITLE
Fix warnings emitted from hugo

### DIFF
--- a/exampleSite/README.md
+++ b/exampleSite/README.md
@@ -26,4 +26,4 @@ hugo server -t YOURTHEME
 - A headless bundle called `homepage` that you may want to use for single page applications. You can find instructions about headless bundles over [here](https://gohugo.io/content-management/page-bundles/#headless-bundle)
 - An `about.md` that is intended to provide the `/about/` page for a theme demo
 
-6. If you intend to build a theme that does not fit in the content structure provided in this repository, then you are still more than welcome to submit it for review at the [Hugo Themes](https://github.com/gohugoio/hugoThemes/issues) respository
+6. If you intend to build a theme that does not fit in the content structure provided in this repository, then you are still more than welcome to submit it for review at the [Hugo Themes](https://github.com/gohugoio/hugoThemes/issues) repository

--- a/exampleSite/content/post/005-theme-info/index.md
+++ b/exampleSite/content/post/005-theme-info/index.md
@@ -19,7 +19,7 @@ categories:
 
 ## Headline 2
 
-The header image is automatically added if there is a file called `*feature*` or `*cover*`. The first wildcard is prefered over the second one. If there are multiple images the first one is used.
+The header image is automatically added if there is a file called `*feature*` or `*cover*`. The first wildcard is preferred over the second one. If there are multiple images the first one is used.
 
 Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
 

--- a/exampleSite/content/post/emoji-support.md
+++ b/exampleSite/content/post/emoji-support.md
@@ -17,7 +17,7 @@ To enable emoji globally, set `enableEmoji` to `true` in your site's [configurat
 <p><span class="nowrap"><span class="emojify">🙈</span> <code>:see_no_evil:</code></span>  <span class="nowrap"><span class="emojify">🙉</span> <code>:hear_no_evil:</code></span>  <span class="nowrap"><span class="emojify">🙊</span> <code>:speak_no_evil:</code></span></p>
 <br>
 
-The [Emoji cheat sheet](http://www.emoji-cheat-sheet.com/) is a useful reference for emoji shorthand codes.
+The [Emoji cheat sheet](https://www.webfx.com/tools/emoji-cheat-sheet/) is a useful reference for emoji shorthand codes.
 
 ***
 

--- a/exampleSite/content/post/math-typesetting.md
+++ b/exampleSite/content/post/math-typesetting.md
@@ -21,17 +21,17 @@ In this example we will be using [KaTeX](https://katex.org/)
 {{ end }}
 ```
 
-- To enable KaTex globally set the parameter `math` to `true` in a project's configuration
-- To enable KaTex on a per page basis include the parameter `math: true` in content files
+- To enable KaTeX globally set the parameter `math` to `true` in a project's configuration
+- To enable KaTeX on a per page basis include the parameter `math: true` in content files
 
 **Note:** Use the online reference of [Supported TeX Functions](https://katex.org/docs/supported.html)
 
 {{< math.inline >}}
 {{ if or .Page.Params.math .Site.Params.math }}
 <!-- KaTeX -->
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
-<script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
-<script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous" onload="renderMathInElement(document.body);"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" integrity="sha384-nB0miv6/jRmo5UMMR1wu3Gz6NLsoTkbqJghGIsx//Rlm+ZU03BU6SQNC66uf4l5+" crossorigin="anonymous">
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js" integrity="sha384-7zkQWkzuo3B5mTepMUcHkMB5jZaolc2xDwL6VFqjFALcbeS9Ggm/Yr2r3Dy4lfFg" crossorigin="anonymous"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js" integrity="sha384-43gviWU0YVjaDtb/GhzOouOXtZMP/7XUzwPTstBeZFe/+rCMvRwr4yROQP43s0Xk" crossorigin="anonymous" onload="renderMathInElement(document.body);"></script>
 {{ end }}
 {{</ math.inline >}}
 

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -171,3 +171,8 @@ series = "series"
 
   [services.twitter]
     disableInlineCSS = true
+
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true


### PR DESCRIPTION
When running example site with latest hugo version 0.139.3, warnings are shown:

```
WARN  Raw HTML omitted while rendering "/home/andreas/bootstrap-bp-hugo-theme/exampleSite/content/post/emoji-support.md"; see https://gohugo.io/getting-started/configuration-markup/#rendererunsafe
You can suppress this warning by adding the following to your site configuration:
ignoreLogs = ['warning-goldmark-raw-html']
WARN  Raw HTML omitted while rendering "/home/andreas/bootstrap-bp-hugo-theme/exampleSite/content/post/placeholder-text.md"; see https://gohugo.io/getting-started/configuration-markup/#rendererunsafe
You can suppress this warning by adding the following to your site configuration:
ignoreLogs = ['warning-goldmark-raw-html']
WARN  Raw HTML omitted while rendering "/home/andreas/bootstrap-bp-hugo-theme/exampleSite/content/post/rich-content.md"; see https://gohugo.io/getting-started/configuration-markup/#rendererunsafe
You can suppress this warning by adding the following to your site configuration:
ignoreLogs = ['warning-goldmark-raw-html']
WARN  Raw HTML omitted while rendering "/home/andreas/bootstrap-bp-hugo-theme/exampleSite/content/post/markdown-syntax.md"; see https://gohugo.io/getting-started/configuration-markup/#rendererunsafe
```

This PR fixes these warnings.