### PR TITLE
fix: replace deprecated Hugo language APIs removed in v0.158.0+

### DIFF
--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -2,7 +2,7 @@ baseURL = "https://gohugo.io"
 title = "Hugo Themes"
 # author = "Steve Francia"
 # copyright = "Copyright © 2008–2019, Steve Francia and the Hugo Authors; all rights reserved."
-languageCode = "en"
+locale = "en"
 DefaultContentLanguage = "en"
 enableInlineShortcodes = true
 # prevent build failures when using Hugo's Instagram shortcode due to deprecated Instagram API.
@@ -53,12 +53,12 @@ theme="bootstrap-bp-hugo-theme"
 
 #[languages]
 #  [languages.en]
-#    languageName = "English"
+#    label = "English"
 #    title = "My blog"
 #    weight = 1
 #    [languages.en.params]
 #  [languages.de]
-#    languageName = "Deutsch"
+#    label = "Deutsch"
 #    title = "Mein Blog"
 #    weight = 2
 #    [languages.de.params]

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{.Site.Language.Lang }}">
+<html lang="{{ .Site.Language.Name }}">
     <meta charset="utf-8">
     <title>{{ block "title" . }}{{ .Site.Title }}{{ end }}</title>
     {{- partial "head.html" . -}}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{.Site.Language.Lang }}">
+<html lang="{{ .Site.Language.Name }}">
     <head>
         <meta charset="utf-8">
         {{- partial "seo_schema" . -}}

--- a/layouts/partials/i18nlist.html
+++ b/layouts/partials/i18nlist.html
@@ -5,14 +5,14 @@
             <li><a href="{{ .RelPermalink }}">{{ if .Title }}{{ .Title }}{{ else }}{{ .Site.Title }}{{ end }} ({{ .Lang }})</a></li>
         {{ end}}
         {{ range $.Site.Home.AllTranslations }}
-            <li><a href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a></li>
+            <li><a href="{{ .RelPermalink }}">{{ .Language.Label }}</a></li>
         {{ end }}
     </ul>
 {{ else if gt (len $.Site.Home.AllTranslations) 0 }}
     <h5>{{ i18n "translations" }}</h5>
     <ul class="list-unstyled">
         {{ range $.Site.Home.AllTranslations }}
-            <li><a href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a></li>
+            <li><a href="{{ .RelPermalink }}">{{ .Language.Label }}</a></li>
         {{ end }}
     </ul>
 {{ end }}


### PR DESCRIPTION
## Summary

Hugo has turned several previously-deprecated language template/config APIs into **fatal errors**, so the theme currently fails to build on up-to-date Hugo (tested with `v0.164.0+extended`). This PR replaces them with their supported equivalents.

Fixes #28

## Changes

| File | Before | After | Deprecated in |
| --- | --- | --- | --- |
| `exampleSite/hugo.toml` | `languageCode = "en"` | `locale = "en"` | Hugo v0.158.0 |
| `layouts/partials/i18nlist.html` (2x) | `.Language.LanguageName` | `.Language.Label` | Hugo v0.158.0 |
| `layouts/_default/baseof.html`, `layouts/404.html` | `.Site.Language.Lang` | `.Site.Language.Name` | Hugo v0.158.0 |
| `exampleSite/hugo.toml` (commented multilingual example) | `languageName` | `label` | Hugo v0.158.0 |

## Error before the fix

```text
ERROR failed to load config: project config key languageCode was deprecated in
Hugo v0.158.0 ... Use locale instead.

... at <.Language.LanguageName>: error calling LanguageName:
.Language.LanguageName was deprecated in Hugo v0.158.0 ... Use .Language.Label instead.
```

## References

- <https://github.com/gohugoio/hugo/releases/tag/v0.158.0>
- <https://gohugo.io/methods/site/language/>
- <https://gohugo.io/configuration/languages/>
